### PR TITLE
Update child-link.txt

### DIFF
--- a/manifests/oot/child-link.txt
+++ b/manifests/oot/child-link.txt
@@ -263,7 +263,7 @@ OBJECT POOL=0x5000,0x800
 			CallList(DL_SWORD_SHIELD_DEKU);
 
       DL_SHEATH0_HYLIAN: // Hylian Shield + Kokiri Sword Sheath
-          CallList( DL_SWORD_SHEATHED );
+          CallList( DL_SWORD_SHEATH );
           CallList( LUT_DL_SHIELD_HYLIAN_BACK );
 		  
 	LUT_DL_SHEATH0_HYLIAN:


### PR DESCRIPTION
Sword should no longer always be sheathed when the Hylian Shield is equipped on child Link